### PR TITLE
Added docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  mongodb: 
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=password
+    networks:
+      - mongo-network
+    volumes:
+      - mongo-data:/data/db
+  
+  mongo-express:
+    image: mongo-express:latest
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=admin
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=password
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+    networks:
+      - mongo-network
+
+networks:
+  mongo-network:
+    driver: bridge
+
+volumes:
+  mongo-data:
+    driver: local


### PR DESCRIPTION
### 🛠️ Fixes #127 
Closes #127 

### 👨‍💻 Description
- Adde a docker-compose file that includes the setup for mongo DB and mongo-express, volumes and network. Contributers can run this file by running cmd `docker-compose up` and use the user and password of the docker container to connect to MongoDB.

### 📄 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### 📷 Screenshots/GIFs (if any)
Include screenshots or GIFs to demonstrate your changes

### ✅ Checklist
- [x] I am a participant of GSSoC-ext.
- [x] I have followed the contribution guidelines of this project.
- [x] I have viewed deployment of my code.
- [x] My changes generate no new warnings.
- [x] I have added documentation to explain my changes.

### 🤝 GSSoC Participation
- [x] This PR is submitted under the GSSoC program.
- [x] I have taken prior approval for this feature/fix.
